### PR TITLE
feat: allow to create hashicorp_binary_bin_dir and hashicorp_binary_l…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ name | required | default | description
 hashicorp_binary_name | yes | | https://releases.hashicorp.com/
 hashicorp_binary_arch: | yes | | linux_amd64, etc
 hashicorp_binary_version | yes | | installed binary version
-hashicorp_binary_lib_dir | no | /usr/local/lib | The install path
-hashicorp_binary_bin_dir | no | /usr/local/bin | The install path
+hashicorp_binary_lib_dir | no | /usr/local/lib | The install path. This directory is generated if it doesn't exist
+hashicorp_binary_bin_dir | no | /usr/local/bin | The install path. This directory is generated if it doesn't exist
 
 ## Dependencies
 
@@ -35,6 +35,13 @@ Nothing.
     hashicorp_binary_version: 0.9.11
     hashicorp_binary_lib_dir: /usr/local/lib
     hashicorp_binary_bin_dir: /usr/local/bin
+    become: yes
+  - role: suzuki-shunsuke.hashicorp-binary
+    hashicorp_binary_name: consul
+    hashicorp_binary_arch: linux_amd64
+    hashicorp_binary_version: 0.8.4
+    hashicorp_binary_lib_dir: "{{ansible_env.HOME}}/lib"
+    hashicorp_binary_bin_dir: "{{ansible_env.HOME}}/bin"
 ```
 
 ## Change Log

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,18 +17,26 @@
       url: "https://releases.hashicorp.com/{{hashicorp_binary_name}}/{{hashicorp_binary_version}}/{{hashicorp_binary_name}}_{{hashicorp_binary_version}}_{{hashicorp_binary_arch}}.zip"
       dest: /tmp
       mode: 0777
+    become: no
   - include: "{{ hashicorp_binary_os_families.get(ansible_os_family, 'default') }}.yml"
     static: no
     when: ansible_os_family in hashicorp_binary_os_families
   - name: unzip the package
     command: "unzip /tmp/{{hashicorp_binary_name}}_{{hashicorp_binary_version}}_{{hashicorp_binary_arch}}.zip -d /tmp"
+    become: no
+  - name: create directories
+    file:
+      state: directory
+      dest: "{{item}}"
+    items:
+    - "{{hashicorp_binary_lib_dir}}"
+    - "{{hashicorp_binary_bin_dir}}"
   - name: install hashicorp's binary
     copy:
       src: /tmp/{{hashicorp_binary_name}}
       dest: "{{hashicorp_binary_lib_dir}}/{{hashicorp_binary_name}}-{{hashicorp_binary_version}}"
       remote_src: yes
       mode: 0755
-    become: "{{hashicorp_binary_nonroot}}"
   - name: remove files in /tmp
     file:
       state: absent
@@ -36,17 +44,16 @@
     with_items:
     - "{{hashicorp_binary_name}}_{{hashicorp_binary_version}}_{{hashicorp_binary_arch}}.zip"
     - "{{hashicorp_binary_name}}"
+    become: no
   - name: remove installed binary
     file:
       state: absent
       path: "{{hashicorp_binary_bin_dir}}/{{hashicorp_binary_name}}"
-    become: "{{hashicorp_binary_nonroot}}"
   - name: create symbolic link
     file:
       state: link
       src: "{{hashicorp_binary_lib_dir}}/{{hashicorp_binary_name}}-{{hashicorp_binary_version}}"
       dest: "{{hashicorp_binary_bin_dir}}/{{hashicorp_binary_name}}"
-    become: "{{hashicorp_binary_nonroot}}"
   when: not lib_stat.stat.exists
 - block:
   - name: check whether the binary has already installed
@@ -57,12 +64,10 @@
     file:
       state: absent
       path: "{{hashicorp_binary_bin_dir}}/{{hashicorp_binary_name}}"
-    become: "{{hashicorp_binary_nonroot}}"
     when: not st.stat.islnk or st.stat.lnk_source != "{}/{}-{}".format(hashicorp_binary_lib_dir, hashicorp_binary_name, hashicorp_binary_version)
   - name: create symbolic link
     file:
       state: link
       src: "{{hashicorp_binary_lib_dir}}/{{hashicorp_binary_name}}-{{hashicorp_binary_version}}"
       dest: "{{hashicorp_binary_bin_dir}}/{{hashicorp_binary_name}}"
-    become: "{{hashicorp_binary_nonroot}}"
   when: lib_stat.stat.exists

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -5,7 +5,14 @@
   - role: ansible-hashicorp-binary
     hashicorp_binary_name: terraform
     hashicorp_binary_arch: linux_amd64
+    hashicorp_binary_version: 0.9.10
+    become: yes
+  - role: ansible-hashicorp-binary
+    hashicorp_binary_name: terraform
+    hashicorp_binary_arch: linux_amd64
     hashicorp_binary_version: 0.8.4
+    hashicorp_binary_lib_dir: "{{ansible_env.HOME}}/bin"
+    hashicorp_binary_bin_dir: "{{ansible_env.HOME}}/bin"
   tasks:
   - command: terraform version
     register: result


### PR DESCRIPTION
…ib_dir

BREAKING CHANGE: If the remote user does not have the write permission of `hashicorp_binary_bin_dir` and
`hashicorp_binary_lib_dir`, the role level become option is required.